### PR TITLE
feat: add lane selector and top-center ASE radar

### DIFF
--- a/web/ase-styles.css
+++ b/web/ase-styles.css
@@ -16,12 +16,14 @@ body {
 
 .ase-window {
     position: fixed;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
     width: 320px;
-    height: 200px;
     background: linear-gradient(135deg, rgba(11, 26, 54, 0.95) 0%, rgba(26, 35, 50, 0.95) 50%, rgba(15, 20, 25, 0.95) 100%);
     border: 1px solid rgba(42, 63, 95, 0.8);
     border-radius: 8px;
-    box-shadow: 
+    box-shadow:
         0 4px 16px rgba(0, 0, 0, 0.3),
         0 0 0 1px rgba(255, 255, 255, 0.05),
         inset 0 1px 0 rgba(255, 255, 255, 0.1);
@@ -348,6 +350,40 @@ body {
     color: #b0b0b0;
     font-weight: 500;
     letter-spacing: 0.5px;
+}
+
+.plate-section,
+.status-section {
+    display: none;
+}
+
+/* Lane selector */
+.lane-selector {
+    display: flex;
+    justify-content: center;
+    gap: 4px;
+    margin-top: 8px;
+}
+
+.lane-btn {
+    padding: 2px 4px;
+    font-size: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(255, 255, 255, 0.1);
+    color: #eaeaea;
+    border-radius: 3px;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.lane-btn:hover {
+    background: rgba(255, 255, 255, 0.2);
+}
+
+.lane-btn.selected {
+    background: rgba(0, 150, 255, 0.3);
+    border-color: rgba(0, 150, 255, 0.5);
+    box-shadow: 0 0 4px rgba(0, 150, 255, 0.3);
 }
 
 .patrol-speed {

--- a/web/ase-window.html
+++ b/web/ase-window.html
@@ -53,8 +53,18 @@
                 </div>
             </div>
 
-            <!-- Plate Reader Section -->
-            <div class="plate-section">
+            <!-- Lane Selector -->
+            <div class="lane-selector">
+                <button class="lane-btn" data-lane="1">1</button>
+                <button class="lane-btn" data-lane="2">2</button>
+                <button class="lane-btn" data-lane="3">3</button>
+                <button class="lane-btn" data-lane="4">4</button>
+                <button class="lane-btn" data-lane="5">5</button>
+                <button class="lane-btn" data-lane="6">6</button>
+            </div>
+
+            <!-- Hidden Plate Reader Section for compatibility -->
+            <div class="plate-section" style="display: none;">
                 <div class="plate-reader">
                     <div class="plate-display">
                         <div class="plate-container">
@@ -69,8 +79,8 @@
                 </div>
             </div>
 
-            <!-- Status Indicators -->
-            <div class="status-section">
+            <!-- Hidden Status Indicators for compatibility -->
+            <div class="status-section" style="display: none;">
                 <div class="status-indicators">
                     <div class="status-item">
                         <div class="status-dot" id="radar-status-dot"></div>
@@ -86,10 +96,8 @@
                     </div>
                 </div>
             </div>
-        </div>
 
-        <!-- Resize Handle -->
-        <div class="ase-resize-handle"></div>
+        </div>
     </div>
 
     <script src="ase-window.js"></script>

--- a/web/ase-window.js
+++ b/web/ase-window.js
@@ -8,6 +8,7 @@ class ASEWindow {
         this.patrolSpeed = 0;
         this.currentPlate = null;
         this.speedLimit = 35;
+        this.selectedLane = null;
         
         this.initializeElements();
         this.setupEventListeners();
@@ -28,12 +29,15 @@ class ASEWindow {
         this.plateGlyphs = document.getElementById('plate-glyphs');
         this.plateText = document.getElementById('plate-text');
         this.plateSource = document.getElementById('plate-source');
-        
+
         // Status indicators
         this.radarStatusDot = document.getElementById('radar-status-dot');
         this.laserStatusDot = document.getElementById('laser-status-dot');
         this.plateStatusDot = document.getElementById('plate-status-dot');
         this.patrolSpeedValue = document.getElementById('patrol-speed');
+
+        // Lane buttons
+        this.laneButtons = document.querySelectorAll('.lane-btn');
     }
 
     setupEventListeners() {
@@ -47,10 +51,18 @@ class ASEWindow {
             this.close();
         });
 
+        // Lane buttons
+        this.laneButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const lane = parseInt(btn.dataset.lane);
+                this.selectLane(lane);
+            });
+        });
+
         // Keyboard controls
         document.addEventListener('keydown', (event) => {
             if (!this.isOpen) return;
-            
+
             switch (event.key.toLowerCase()) {
                 case 'escape':
                     this.close();
@@ -60,6 +72,14 @@ class ASEWindow {
                     break;
                 case 'l':
                     this.toggleLaserMode();
+                    break;
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                    this.selectLane(parseInt(event.key));
                     break;
             }
         });
@@ -176,11 +196,11 @@ class ASEWindow {
         this.isOpen = true;
         this.window.style.display = 'block';
         
-        // Position window in center if not positioned
+        // Position window at top center if not positioned
         if (!this.window.style.left && !this.window.style.top) {
             this.window.style.left = '50%';
-            this.window.style.top = '50%';
-            this.window.style.transform = 'translate(-50%, -50%)';
+            this.window.style.top = '20px';
+            this.window.style.transform = 'translateX(-50%)';
         }
         
         this.updateUI();
@@ -220,6 +240,24 @@ class ASEWindow {
         
         this.updateUI();
         this.sendNui('aseLaserToggle', { laserMode: this.isLaserMode });
+    }
+
+    selectLane(lane) {
+        if (lane < 1 || lane > 6) return;
+
+        // Toggle lane selection
+        if (this.selectedLane === lane) {
+            this.selectedLane = null;
+        } else {
+            this.selectedLane = lane;
+        }
+
+        // Update button states
+        this.laneButtons.forEach(btn => {
+            btn.classList.toggle('selected', parseInt(btn.dataset.lane) === this.selectedLane);
+        });
+
+        this.sendNui('aseLaneSelected', { lane: this.selectedLane });
     }
 
     onSpeedDetected(data) {


### PR DESCRIPTION
## Summary
- position ASE radar window at top center of the screen
- add lane selector buttons with keyboard support for laser targeting
- hide legacy plate and status sections to streamline UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcd56d8ec83208a8877bc9d3221ba