### PR TITLE
feat: redesign ASE window with scoped styles

### DIFF
--- a/web/ase-styles.css
+++ b/web/ase-styles.css
@@ -1,411 +1,109 @@
-/* ASE Speed Enforcement Window - Compact Modern LSPD Design */
-@import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@300;400;500;600;700&display=swap');
+/* ASE Speed Enforcement window */
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap');
 
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+#ase-window {
+  position: absolute;
+  top: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 300px;
+  background: rgba(11,26,54,0.95);
+  border: 1px solid rgba(42,63,95,0.8);
+  border-radius: 8px;
+  color: #fff;
+  font-family: 'Roboto Condensed', sans-serif;
+  z-index: 1000;
 }
 
-body {
-    font-family: 'Roboto Condensed', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    background: transparent;
-    overflow: hidden;
-    user-select: none;
+#ase-window .ase-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: rgba(30,58,138,0.9);
+  border-bottom: 1px solid rgba(42,63,95,0.8);
 }
 
-.ase-window {
-    position: fixed;
-    width: 320px;
-    height: 200px;
-    background: linear-gradient(135deg, rgba(11, 26, 54, 0.95) 0%, rgba(26, 35, 50, 0.95) 50%, rgba(15, 20, 25, 0.95) 100%);
-    border: 1px solid rgba(42, 63, 95, 0.8);
-    border-radius: 8px;
-    box-shadow: 
-        0 4px 16px rgba(0, 0, 0, 0.3),
-        0 0 0 1px rgba(255, 255, 255, 0.05),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    cursor: default;
-    overflow: hidden;
-    backdrop-filter: blur(10px);
-    z-index: 1000;
+#ase-window .ase-header .title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: .5px;
 }
 
-.ase-window.interactive {
-    cursor: move;
+#ase-window .ase-header .ase-controls {
+  display: flex;
+  gap: 6px;
 }
 
-/* Header */
-.ase-header {
-    background: linear-gradient(90deg, rgba(11, 26, 54, 0.9) 0%, rgba(30, 58, 138, 0.9) 50%, rgba(11, 26, 54, 0.9) 100%);
-    padding: 8px 12px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    border-bottom: 1px solid rgba(42, 63, 95, 0.6);
-    position: relative;
-    z-index: 2;
-    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+#ase-window .ase-header button {
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #fff;
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 3px;
+  cursor: pointer;
 }
 
-.ase-title {
-    display: flex;
-    align-items: center;
-    gap: 8px;
+#ase-window .ase-header .close-btn {
+  font-size: 14px;
+  line-height: 1;
 }
 
-.ase-icon {
-    width: 20px;
-    height: 20px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 3px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 12px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+#ase-window .radar {
+  display: flex;
+  padding: 10px;
+  gap: 10px;
+  background: rgba(0,0,0,0.3);
 }
 
-.ase-title-text {
-    font-size: 12px;
-    font-weight: 600;
-    color: #eaeaea;
-    letter-spacing: 0.5px;
+#ase-window .section {
+  flex: 1;
+  text-align: center;
 }
 
-.ase-controls {
-    display: flex;
-    align-items: center;
-    gap: 6px;
+#ase-window .label {
+  font-size: 10px;
+  font-weight: 600;
+  margin-bottom: 4px;
+  display: block;
 }
 
-.ase-btn {
-    padding: 4px 8px;
-    border: none;
-    border-radius: 4px;
-    background: rgba(255, 255, 255, 0.1);
-    color: #eaeaea;
-    font-size: 10px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    border: 1px solid rgba(255, 255, 255, 0.2);
+#ase-window .digits {
+  font-family: 'Courier New', monospace;
+  font-size: 32px;
+  background: #000;
+  border: 2px solid #333;
+  border-radius: 4px;
+  padding: 4px 8px;
+  color: #ff6b35;
+  text-shadow: 0 0 10px rgba(255,107,53,0.6);
 }
 
-.ase-btn:hover {
-    background: rgba(255, 255, 255, 0.2);
-    transform: translateY(-1px);
+#ase-window .digits.green {
+  color: #00ff66;
+  text-shadow: 0 0 10px rgba(0,255,102,0.5);
 }
 
-.ase-btn.active {
-    background: rgba(0, 150, 255, 0.3);
-    border-color: rgba(0, 150, 255, 0.5);
-    box-shadow: 0 0 8px rgba(0, 150, 255, 0.3);
+#ase-window .lane-selector {
+  display: flex;
+  gap: 6px;
+  padding: 8px 10px 10px;
+  justify-content: center;
 }
 
-.close-btn {
-    background: rgba(255, 100, 100, 0.2);
-    border-color: rgba(255, 100, 100, 0.4);
-    font-size: 14px;
-    padding: 2px 6px;
+#ase-window .lane-btn {
+  flex: 1;
+  background: rgba(255,255,255,0.1);
+  border: 1px solid rgba(255,255,255,0.2);
+  color: #fff;
+  font-size: 12px;
+  padding: 4px 0;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
-.close-btn:hover {
-    background: rgba(255, 100, 100, 0.4);
-}
-
-/* Main Content */
-.ase-content {
-    padding: 12px;
-    height: calc(100% - 40px);
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
-
-/* Radar Gun Display */
-.radar-display {
-    flex: 1;
-    display: flex;
-    gap: 8px;
-    height: 100%;
-    background: rgba(0, 0, 0, 0.3);
-    border: 1px solid rgba(42, 63, 95, 0.6);
-    border-radius: 4px;
-    padding: 8px;
-}
-
-.radar-section {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-}
-
-.section-label {
-    font-size: 10px;
-    font-weight: 600;
-    color: #ffffff;
-    letter-spacing: 0.5px;
-    margin-bottom: 8px;
-    text-align: center;
-}
-
-.speed-readout {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.digital-display {
-    font-family: 'Courier New', monospace;
-    font-size: 28px;
-    font-weight: 700;
-    color: #ff6b35;
-    text-align: center;
-    line-height: 1;
-    background: rgba(0, 0, 0, 0.8);
-    border: 2px solid #333;
-    border-radius: 4px;
-    padding: 4px 8px;
-    min-width: 60px;
-    text-shadow: 0 0 10px rgba(255, 107, 53, 0.5);
-    box-shadow: inset 0 0 10px rgba(0, 0, 0, 0.5);
-}
-
-.patrol-section {
-    background: rgba(0, 50, 0, 0.2);
-    border: 1px solid rgba(0, 100, 0, 0.4);
-    border-radius: 4px;
-    padding: 8px;
-}
-
-.patrol-label {
-    font-size: 8px;
-    font-weight: 600;
-    color: #ffffff;
-    letter-spacing: 0.5px;
-    margin-bottom: 8px;
-    text-align: center;
-}
-
-.patrol-readout {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.patrol-display {
-    color: #00ff00;
-    text-shadow: 0 0 10px rgba(0, 255, 0, 0.5);
-    background: rgba(0, 0, 0, 0.9);
-    border-color: #00aa00;
-}
-
-/* Speed color coding */
-.digital-display.under-limit {
-    color: #4ade80;
-    text-shadow: 0 0 10px rgba(74, 222, 128, 0.5);
-}
-
-.digital-display.close-limit {
-    color: #fbbf24;
-    text-shadow: 0 0 10px rgba(251, 191, 36, 0.5);
-}
-
-.digital-display.over-limit {
-    color: #ff4444;
-    text-shadow: 0 0 15px rgba(255, 68, 68, 0.8);
-    animation: pulse-red 1s infinite;
-}
-
-@keyframes pulse-red {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.7; }
-}
-
-/* Plate Section */
-.plate-section {
-    height: 40px;
-}
-
-.plate-reader {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    height: 100%;
-}
-
-.plate-display {
-    flex-shrink: 0;
-}
-
-.plate-container {
-    position: relative;
-    width: 80px;
-    height: 24px;
-}
-
-.plate-background {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    border-radius: 2px;
-}
-
-.plate-glyphs {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1px;
-}
-
-.plate-glyphs .glyph {
-    width: 8px;
-    height: 16px;
-    object-fit: contain;
-}
-
-.plate-info {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
-.plate-text {
-    font-size: 12px;
-    font-weight: 600;
-    color: #ffffff;
-    letter-spacing: 1px;
-    margin-bottom: 2px;
-}
-
-.plate-source {
-    font-size: 8px;
-    color: #888;
-    font-weight: 500;
-}
-
-/* Status Section */
-.status-section {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    height: 20px;
-}
-
-.status-indicators {
-    display: flex;
-    gap: 8px;
-}
-
-.status-item {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-}
-
-.status-dot {
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
-    background: #444;
-    border: 1px solid #666;
-}
-
-.status-dot.active {
-    background: #4ade80;
-    border-color: #22c55e;
-    box-shadow: 0 0 6px rgba(74, 222, 128, 0.5);
-}
-
-.status-dot.scanning {
-    background: #fbbf24;
-    border-color: #f59e0b;
-    animation: pulse-yellow 1s infinite;
-}
-
-@keyframes pulse-yellow {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.6; }
-}
-
-.status-text {
-    font-size: 8px;
-    color: #b0b0b0;
-    font-weight: 500;
-    letter-spacing: 0.5px;
-}
-
-.patrol-speed {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-size: 8px;
-    color: #888;
-}
-
-.patrol-label {
-    font-weight: 500;
-}
-
-.patrol-value {
-    font-weight: 600;
-    color: #ffffff;
-}
-
-.patrol-unit {
-    font-weight: 500;
-}
-
-/* Resize Handle */
-.ase-resize-handle {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    width: 12px;
-    height: 12px;
-    background: linear-gradient(-45deg, transparent 0%, transparent 30%, rgba(255, 255, 255, 0.1) 30%, rgba(255, 255, 255, 0.1) 70%, transparent 70%);
-    cursor: se-resize;
-    opacity: 0;
-    transition: opacity 0.2s ease;
-}
-
-.ase-window:hover .ase-resize-handle {
-    opacity: 1;
-}
-
-/* Drag functionality */
-.ase-window.dragging {
-    cursor: move !important;
-}
-
-/* Responsive adjustments */
-@media (max-width: 400px) {
-    .ase-window {
-        width: 280px;
-        height: 180px;
-    }
-    
-    .speed-display {
-        font-size: 20px;
-    }
-    
-    .plate-container {
-        width: 70px;
-        height: 20px;
-    }
+#ase-window .lane-btn.active {
+  background: rgba(0,150,255,0.3);
+  border-color: rgba(0,150,255,0.6);
 }

--- a/web/ase-styles.css
+++ b/web/ase-styles.css
@@ -45,6 +45,11 @@
   cursor: pointer;
 }
 
+#ase-window .ase-header #ase-mode-btn.laser {
+  background: rgba(0,150,255,0.3);
+  border-color: rgba(0,150,255,0.6);
+}
+
 #ase-window .ase-header .close-btn {
   font-size: 14px;
   line-height: 1;
@@ -90,6 +95,10 @@
   gap: 6px;
   padding: 8px 10px 10px;
   justify-content: center;
+}
+
+#ase-window .lane-selector.hidden {
+  display: none;
 }
 
 #ase-window .lane-btn {

--- a/web/ase-styles.css
+++ b/web/ase-styles.css
@@ -2,11 +2,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Condensed:wght@400;700&display=swap');
 
 #ase-window {
-  position: absolute;
+  position: fixed;
   top: 20px;
   left: 50%;
   transform: translateX(-50%);
-  width: 300px;
+  width: 360px;
   background: rgba(11,26,54,0.95);
   border: 1px solid rgba(42,63,95,0.8);
   border-radius: 8px;
@@ -24,18 +24,24 @@
   border-bottom: 1px solid rgba(42,63,95,0.8);
 }
 
-#ase-window .ase-header .title {
+#ase-window .ase-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#ase-window .ase-title-text {
   font-size: 12px;
   font-weight: 600;
   letter-spacing: .5px;
 }
 
-#ase-window .ase-header .ase-controls {
+#ase-window .ase-controls {
   display: flex;
   gap: 6px;
 }
 
-#ase-window .ase-header button {
+#ase-window .ase-btn {
   background: rgba(255,255,255,0.1);
   border: 1px solid rgba(255,255,255,0.2);
   color: #fff;
@@ -43,38 +49,43 @@
   padding: 2px 6px;
   border-radius: 3px;
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
 }
 
-#ase-window .ase-header #ase-mode-btn.laser {
-  background: rgba(0,150,255,0.3);
-  border-color: rgba(0,150,255,0.6);
-}
-
-#ase-window .ase-header .close-btn {
+#ase-window .ase-btn.close-btn {
   font-size: 14px;
   line-height: 1;
 }
 
-#ase-window .radar {
-  display: flex;
+#ase-window .ase-btn.mode-btn.laser {
+  background: rgba(0,150,255,0.3);
+  border-color: rgba(0,150,255,0.6);
+}
+
+#ase-window .ase-content {
   padding: 10px;
-  gap: 10px;
   background: rgba(0,0,0,0.3);
 }
 
-#ase-window .section {
+#ase-window .radar-display {
+  display: flex;
+  gap: 10px;
+}
+
+#ase-window .radar-section {
   flex: 1;
   text-align: center;
 }
 
-#ase-window .label {
+#ase-window .section-label {
   font-size: 10px;
   font-weight: 600;
   margin-bottom: 4px;
-  display: block;
 }
 
-#ase-window .digits {
+#ase-window .digital-display {
   font-family: 'Courier New', monospace;
   font-size: 32px;
   background: #000;
@@ -85,7 +96,7 @@
   text-shadow: 0 0 10px rgba(255,107,53,0.6);
 }
 
-#ase-window .digits.green {
+#ase-window .digital-display.patrol-display {
   color: #00ff66;
   text-shadow: 0 0 10px rgba(0,255,102,0.5);
 }
@@ -93,7 +104,7 @@
 #ase-window .lane-selector {
   display: flex;
   gap: 6px;
-  padding: 8px 10px 10px;
+  margin-top: 10px;
   justify-content: center;
 }
 

--- a/web/ase-window.html
+++ b/web/ase-window.html
@@ -7,36 +7,96 @@
   <link rel="stylesheet" href="ase-styles.css">
 </head>
 <body>
-  <div id="ase-window">
+  <!-- ASE Speed Enforcement Window -->
+  <div id="ase-window" class="ase-window" style="display: none;">
+    <!-- Header -->
     <div class="ase-header">
-      <span class="title">SPEED ENFORCEMENT</span>
+      <div class="ase-title">
+        <div class="ase-icon">📡</div>
+        <div class="ase-title-text">SPEED ENFORCEMENT</div>
+      </div>
       <div class="ase-controls">
-        <button id="ase-mode-btn" class="mode-btn">RADAR</button>
-        <button id="ase-power-btn">POWER</button>
-        <button id="ase-close-btn" class="close-btn">×</button>
+        <button class="ase-btn mode-btn" id="ase-mode-btn">RADAR</button>
+        <button class="ase-btn power-btn" id="ase-power-btn">
+          <span class="btn-icon">⚡</span>
+          <span class="btn-text">POWER</span>
+        </button>
+        <button class="ase-btn close-btn" id="ase-close-btn">×</button>
       </div>
     </div>
-    <div class="radar">
-      <div class="section">
-        <span class="label">FRONT</span>
-        <span id="front-speed" class="digits">000</span>
+
+    <!-- Main Content -->
+    <div class="ase-content">
+      <!-- Radar Gun Display -->
+      <div class="radar-display">
+        <!-- Front Section -->
+        <div class="radar-section front-section">
+          <div class="section-label">FRONT</div>
+          <div class="speed-readout">
+            <div class="digital-display" id="front-speed">000</div>
+          </div>
+        </div>
+
+        <!-- Rear Section -->
+        <div class="radar-section rear-section">
+          <div class="section-label">REAR</div>
+          <div class="speed-readout">
+            <div class="digital-display" id="rear-speed">000</div>
+          </div>
+        </div>
+
+        <!-- Patrol Speed Section -->
+        <div class="radar-section patrol-section">
+          <div class="patrol-label">PATROL SPEED</div>
+          <div class="patrol-readout">
+            <div class="digital-display patrol-display" id="patrol-speed">000</div>
+          </div>
+        </div>
       </div>
-      <div class="section">
-        <span class="label">REAR</span>
-        <span id="rear-speed" class="digits">000</span>
+
+      <!-- Lane Selector -->
+      <div class="lane-selector hidden">
+        <button class="lane-btn" data-lane="1">1</button>
+        <button class="lane-btn" data-lane="2">2</button>
+        <button class="lane-btn" data-lane="3">3</button>
+        <button class="lane-btn" data-lane="4">4</button>
+        <button class="lane-btn" data-lane="5">5</button>
+        <button class="lane-btn" data-lane="6">6</button>
       </div>
-      <div class="section">
-        <span class="label">PATROL</span>
-        <span id="patrol-speed" class="digits green">000</span>
+
+      <!-- Hidden Plate Reader Section for compatibility -->
+      <div class="plate-section" style="display: none;">
+        <div class="plate-reader">
+          <div class="plate-display">
+            <div class="plate-container">
+              <img src="plates/BlueOnWhite1.png" alt="License Plate" class="plate-background">
+              <div class="plate-glyphs" id="plate-glyphs"></div>
+            </div>
+          </div>
+          <div class="plate-info">
+            <div class="plate-text" id="plate-text">NO PLATE</div>
+            <div class="plate-source" id="plate-source">--</div>
+          </div>
+        </div>
       </div>
-    </div>
-    <div class="lane-selector hidden">
-      <button class="lane-btn" data-lane="1">1</button>
-      <button class="lane-btn" data-lane="2">2</button>
-      <button class="lane-btn" data-lane="3">3</button>
-      <button class="lane-btn" data-lane="4">4</button>
-      <button class="lane-btn" data-lane="5">5</button>
-      <button class="lane-btn" data-lane="6">6</button>
+
+      <!-- Hidden Status Indicators for compatibility -->
+      <div class="status-section" style="display: none;">
+        <div class="status-indicators">
+          <div class="status-item">
+            <div class="status-dot" id="radar-status-dot"></div>
+            <span class="status-text">RADAR</span>
+          </div>
+          <div class="status-item">
+            <div class="status-dot" id="laser-status-dot"></div>
+            <span class="status-text">LASER</span>
+          </div>
+          <div class="status-item">
+            <div class="status-dot" id="plate-status-dot"></div>
+            <span class="status-text">ALPR</span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 

--- a/web/ase-window.html
+++ b/web/ase-window.html
@@ -11,6 +11,7 @@
     <div class="ase-header">
       <span class="title">SPEED ENFORCEMENT</span>
       <div class="ase-controls">
+        <button id="ase-mode-btn" class="mode-btn">RADAR</button>
         <button id="ase-power-btn">POWER</button>
         <button id="ase-close-btn" class="close-btn">×</button>
       </div>
@@ -29,7 +30,7 @@
         <span id="patrol-speed" class="digits green">000</span>
       </div>
     </div>
-    <div class="lane-selector">
+    <div class="lane-selector hidden">
       <button class="lane-btn" data-lane="1">1</button>
       <button class="lane-btn" data-lane="2">2</button>
       <button class="lane-btn" data-lane="3">3</button>

--- a/web/ase-window.html
+++ b/web/ase-window.html
@@ -1,97 +1,44 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ASE - Speed Enforcement</title>
-    <link rel="stylesheet" href="ase-styles.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ASE - Speed Enforcement</title>
+  <link rel="stylesheet" href="ase-styles.css">
 </head>
 <body>
-    <!-- ASE Speed Enforcement Window -->
-    <div id="ase-window" class="ase-window" style="display: none;">
-        <!-- Header -->
-        <div class="ase-header">
-            <div class="ase-title">
-                <div class="ase-icon">📡</div>
-                <div class="ase-title-text">SPEED ENFORCEMENT</div>
-            </div>
-            <div class="ase-controls">
-                <button class="ase-btn power-btn" id="ase-power-btn">
-                    <span class="btn-icon">⚡</span>
-                    <span class="btn-text">POWER</span>
-                </button>
-                <button class="ase-btn close-btn" id="ase-close-btn">×</button>
-            </div>
-        </div>
-
-        <!-- Main Content -->
-        <div class="ase-content">
-            <!-- Radar Gun Display -->
-            <div class="radar-display">
-                <!-- Front Section -->
-                <div class="radar-section front-section">
-                    <div class="section-label">FRONT</div>
-                    <div class="speed-readout">
-                        <div class="digital-display" id="front-speed">000</div>
-                    </div>
-                </div>
-
-                <!-- Rear Section -->
-                <div class="radar-section rear-section">
-                    <div class="section-label">REAR</div>
-                    <div class="speed-readout">
-                        <div class="digital-display" id="rear-speed">000</div>
-                    </div>
-                </div>
-
-                <!-- Patrol Speed Section -->
-                <div class="radar-section patrol-section">
-                    <div class="patrol-label">PATROL SPEED</div>
-                    <div class="patrol-readout">
-                        <div class="digital-display patrol-display" id="patrol-speed">000</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Plate Reader Section -->
-            <div class="plate-section">
-                <div class="plate-reader">
-                    <div class="plate-display">
-                        <div class="plate-container">
-                            <img src="plates/BlueOnWhite1.png" alt="License Plate" class="plate-background">
-                            <div class="plate-glyphs" id="plate-glyphs"></div>
-                        </div>
-                    </div>
-                    <div class="plate-info">
-                        <div class="plate-text" id="plate-text">NO PLATE</div>
-                        <div class="plate-source" id="plate-source">--</div>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Status Indicators -->
-            <div class="status-section">
-                <div class="status-indicators">
-                    <div class="status-item">
-                        <div class="status-dot" id="radar-status-dot"></div>
-                        <span class="status-text">RADAR</span>
-                    </div>
-                    <div class="status-item">
-                        <div class="status-dot" id="laser-status-dot"></div>
-                        <span class="status-text">LASER</span>
-                    </div>
-                    <div class="status-item">
-                        <div class="status-dot" id="plate-status-dot"></div>
-                        <span class="status-text">ALPR</span>
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <!-- Resize Handle -->
-        <div class="ase-resize-handle"></div>
+  <div id="ase-window">
+    <div class="ase-header">
+      <span class="title">SPEED ENFORCEMENT</span>
+      <div class="ase-controls">
+        <button id="ase-power-btn">POWER</button>
+        <button id="ase-close-btn" class="close-btn">×</button>
+      </div>
     </div>
+    <div class="radar">
+      <div class="section">
+        <span class="label">FRONT</span>
+        <span id="front-speed" class="digits">000</span>
+      </div>
+      <div class="section">
+        <span class="label">REAR</span>
+        <span id="rear-speed" class="digits">000</span>
+      </div>
+      <div class="section">
+        <span class="label">PATROL</span>
+        <span id="patrol-speed" class="digits green">000</span>
+      </div>
+    </div>
+    <div class="lane-selector">
+      <button class="lane-btn" data-lane="1">1</button>
+      <button class="lane-btn" data-lane="2">2</button>
+      <button class="lane-btn" data-lane="3">3</button>
+      <button class="lane-btn" data-lane="4">4</button>
+      <button class="lane-btn" data-lane="5">5</button>
+      <button class="lane-btn" data-lane="6">6</button>
+    </div>
+  </div>
 
-    <script src="ase-window.js"></script>
+  <script src="ase-window.js"></script>
 </body>
 </html>

--- a/web/ase-window.js
+++ b/web/ase-window.js
@@ -1,392 +1,156 @@
-// ASE Speed Enforcement Window - Compact Modern Interface
 class ASEWindow {
-    constructor() {
-        this.isOpen = false;
-        this.isActive = false;
-        this.isLaserMode = false;
-        this.isScanning = false;
-        this.patrolSpeed = 0;
-        this.currentPlate = null;
-        this.speedLimit = 35;
-        
-        this.initializeElements();
-        this.setupEventListeners();
-        this.initializeNUIListener();
-        this.setupDragFunctionality();
+  constructor() {
+    this.isOpen = false;
+    this.isActive = false;
+    this.selectedLane = null;
+
+    this.initElements();
+    this.setupListeners();
+    this.initNui();
+    this.setupDrag();
+  }
+
+  initElements() {
+    this.window = document.getElementById('ase-window');
+    this.powerBtn = document.getElementById('ase-power-btn');
+    this.closeBtn = document.getElementById('ase-close-btn');
+    this.frontSpeed = document.getElementById('front-speed');
+    this.rearSpeed = document.getElementById('rear-speed');
+    this.patrolSpeed = document.getElementById('patrol-speed');
+    this.laneButtons = document.querySelectorAll('.lane-btn');
+  }
+
+  setupListeners() {
+    this.powerBtn.addEventListener('click', () => this.togglePower());
+    this.closeBtn.addEventListener('click', () => this.close());
+
+    this.laneButtons.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const lane = parseInt(btn.dataset.lane);
+        this.selectLane(lane);
+      });
+    });
+
+    document.addEventListener('keydown', (e) => {
+      if (!this.isOpen) return;
+      switch (e.key.toLowerCase()) {
+        case 'escape':
+          this.close();
+          break;
+        case 'p':
+          this.togglePower();
+          break;
+        case '1': case '2': case '3': case '4': case '5': case '6':
+          this.selectLane(parseInt(e.key));
+          break;
+      }
+    });
+  }
+
+  setupDrag() {
+    const header = this.window.querySelector('.ase-header');
+    let isDragging = false;
+    let offset = { x: 0, y: 0 };
+
+    header.addEventListener('mousedown', (e) => {
+      isDragging = true;
+      offset.x = e.clientX - this.window.offsetLeft;
+      offset.y = e.clientY - this.window.offsetTop;
+      e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!isDragging) return;
+      this.window.style.left = (e.clientX - offset.x) + 'px';
+      this.window.style.top = (e.clientY - offset.y) + 'px';
+    });
+
+    document.addEventListener('mouseup', () => {
+      isDragging = false;
+    });
+  }
+
+  initNui() {
+    window.addEventListener('message', (event) => {
+      const data = event.data;
+      switch (data.action) {
+        case 'ASE_OPEN':
+          this.open();
+          break;
+        case 'ASE_CLOSE':
+          this.close();
+          break;
+        case 'RADAR_SPEED_DETECTED':
+          this.onSpeed(data);
+          break;
+        case 'RADAR_PATROL_SPEED':
+          this.updatePatrolSpeed(data.speed);
+          break;
+      }
+    });
+  }
+
+  open() {
+    this.isOpen = true;
+    this.window.style.display = 'block';
+    this.window.style.top = '20px';
+    this.window.style.left = '50%';
+    this.window.style.transform = 'translateX(-50%)';
+    this.sendNui('aseOpened');
+  }
+
+  close() {
+    this.isOpen = false;
+    this.isActive = false;
+    this.window.style.display = 'none';
+    this.clearData();
+    this.sendNui('aseClosed');
+  }
+
+  togglePower() {
+    this.isActive = !this.isActive;
+    this.powerBtn.classList.toggle('active', this.isActive);
+    if (!this.isActive) {
+      this.clearData();
     }
+    this.sendNui('asePowerToggle', { active: this.isActive });
+  }
 
-    initializeElements() {
-        this.window = document.getElementById('ase-window');
-        this.powerBtn = document.getElementById('ase-power-btn');
-        this.closeBtn = document.getElementById('ase-close-btn');
-        
-        // Speed displays
-        this.frontSpeed = document.getElementById('front-speed');
-        this.rearSpeed = document.getElementById('rear-speed');
-        
-        // Plate elements
-        this.plateGlyphs = document.getElementById('plate-glyphs');
-        this.plateText = document.getElementById('plate-text');
-        this.plateSource = document.getElementById('plate-source');
-        
-        // Status indicators
-        this.radarStatusDot = document.getElementById('radar-status-dot');
-        this.laserStatusDot = document.getElementById('laser-status-dot');
-        this.plateStatusDot = document.getElementById('plate-status-dot');
-        this.patrolSpeedValue = document.getElementById('patrol-speed');
-    }
+  selectLane(lane) {
+    this.selectedLane = this.selectedLane === lane ? null : lane;
+    this.laneButtons.forEach(btn => {
+      btn.classList.toggle('active', parseInt(btn.dataset.lane) === this.selectedLane);
+    });
+    this.sendNui('aseLaneSelected', { lane: this.selectedLane });
+  }
 
-    setupEventListeners() {
-        // Power button
-        this.powerBtn.addEventListener('click', () => {
-            this.togglePower();
-        });
+  onSpeed(data) {
+    if (!this.isActive) return;
+    const { lane, speed, direction } = data;
+    const display = (direction === 'front' || lane <= 3) ? this.frontSpeed : this.rearSpeed;
+    display.textContent = String(speed).padStart(3, '0');
+    this.sendNui('aseSpeedDetected', data);
+  }
 
-        // Close button
-        this.closeBtn.addEventListener('click', () => {
-            this.close();
-        });
+  updatePatrolSpeed(speed) {
+    this.patrolSpeed.textContent = String(speed).padStart(3, '0');
+  }
 
-        // Keyboard controls
-        document.addEventListener('keydown', (event) => {
-            if (!this.isOpen) return;
-            
-            switch (event.key.toLowerCase()) {
-                case 'escape':
-                    this.close();
-                    break;
-                case 'p':
-                    this.togglePower();
-                    break;
-                case 'l':
-                    this.toggleLaserMode();
-                    break;
-            }
-        });
-    }
+  clearData() {
+    this.frontSpeed.textContent = '000';
+    this.rearSpeed.textContent = '000';
+    this.patrolSpeed.textContent = '000';
+    this.selectLane(null);
+  }
 
-    setupDragFunctionality() {
-        const header = this.window.querySelector('.ase-header');
-        let isDragging = false;
-        let dragStart = { x: 0, y: 0 };
-
-        header.addEventListener('mousedown', (e) => {
-            isDragging = true;
-            dragStart = {
-                x: e.clientX - this.getWindowPosition().x,
-                y: e.clientY - this.getWindowPosition().y
-            };
-            this.window.classList.add('dragging');
-            e.preventDefault();
-        });
-
-        document.addEventListener('mousemove', (e) => {
-            if (isDragging) {
-                const newX = e.clientX - dragStart.x;
-                const newY = e.clientY - dragStart.y;
-                
-                // Keep window within viewport bounds
-                const maxX = window.innerWidth - this.window.offsetWidth;
-                const maxY = window.innerHeight - this.window.offsetHeight;
-                
-                this.window.style.left = Math.max(0, Math.min(newX, maxX)) + 'px';
-                this.window.style.top = Math.max(0, Math.min(newY, maxY)) + 'px';
-            }
-        });
-
-        document.addEventListener('mouseup', () => {
-            isDragging = false;
-            this.window.classList.remove('dragging');
-        });
-
-        // Resize functionality
-        const resizeHandle = this.window.querySelector('.ase-resize-handle');
-        let isResizing = false;
-        let resizeStart = { x: 0, y: 0, width: 0, height: 0 };
-
-        resizeHandle.addEventListener('mousedown', (e) => {
-            isResizing = true;
-            resizeStart = {
-                x: e.clientX,
-                y: e.clientY,
-                width: this.window.offsetWidth,
-                height: this.window.offsetHeight
-            };
-            e.preventDefault();
-        });
-
-        document.addEventListener('mousemove', (e) => {
-            if (isResizing) {
-                const deltaX = e.clientX - resizeStart.x;
-                const deltaY = e.clientY - resizeStart.y;
-                
-                const newWidth = Math.max(280, resizeStart.width + deltaX);
-                const newHeight = Math.max(160, resizeStart.height + deltaY);
-                
-                this.window.style.width = newWidth + 'px';
-                this.window.style.height = newHeight + 'px';
-            }
-        });
-
-        document.addEventListener('mouseup', () => {
-            isResizing = false;
-        });
-    }
-
-    initializeNUIListener() {
-        window.addEventListener('message', (event) => {
-            const data = event.data;
-            
-            switch (data.action) {
-                case 'ASE_OPEN':
-                    this.open(data);
-                    break;
-                case 'ASE_CLOSE':
-                    this.close();
-                    break;
-                case 'RADAR_SPEED_DETECTED':
-                    this.onSpeedDetected(data);
-                    break;
-                case 'RADAR_LASER_TARGET':
-                    this.onLaserTarget(data);
-                    break;
-                case 'RADAR_PATROL_SPEED':
-                    this.updatePatrolSpeed(data.speed);
-                    break;
-                case 'RADAR_PLATE_DETECTED':
-                    this.onPlateDetected(data);
-                    break;
-                case 'ALPR_SCAN':
-                    this.onPlateDetected(data);
-                    break;
-                case 'plateDetected':
-                    this.onPlateDetected(data);
-                    break;
-            }
-        });
-    }
-
-    getWindowPosition() {
-        const rect = this.window.getBoundingClientRect();
-        return { x: rect.left, y: rect.top };
-    }
-
-    open(data = {}) {
-        console.log('[ASEWindow] Opening ASE interface');
-        this.isOpen = true;
-        this.window.style.display = 'block';
-        
-        // Position window in center if not positioned
-        if (!this.window.style.left && !this.window.style.top) {
-            this.window.style.left = '50%';
-            this.window.style.top = '50%';
-            this.window.style.transform = 'translate(-50%, -50%)';
-        }
-        
-        this.updateUI();
-        this.sendNui('aseOpened', {});
-    }
-
-    close() {
-        console.log('[ASEWindow] Closing ASE interface');
-        this.isOpen = false;
-        this.isActive = false;
-        this.isLaserMode = false;
-        this.isScanning = false;
-        this.window.style.display = 'none';
-        this.clearAllData();
-        this.sendNui('aseClosed', {});
-    }
-
-    togglePower() {
-        this.isActive = !this.isActive;
-        console.log('[ASEWindow] Power toggled:', this.isActive ? 'ON' : 'OFF');
-        
-        if (!this.isActive) {
-            this.isLaserMode = false;
-            this.isScanning = false;
-            this.clearAllData();
-        }
-        
-        this.updateUI();
-        this.sendNui('asePowerToggle', { active: this.isActive });
-    }
-
-    toggleLaserMode() {
-        if (!this.isActive) return;
-        
-        this.isLaserMode = !this.isLaserMode;
-        console.log('[ASEWindow] Laser mode toggled:', this.isLaserMode ? 'ON' : 'OFF');
-        
-        this.updateUI();
-        this.sendNui('aseLaserToggle', { laserMode: this.isLaserMode });
-    }
-
-    onSpeedDetected(data) {
-        if (!this.isActive) return;
-        
-        const { lane, speed, direction } = data;
-        console.log('[ASEWindow] Speed detected:', speed, 'MPH in', direction, 'lane', lane);
-        
-        // Update appropriate speed display
-        if (direction === 'front' || lane <= 3) {
-            this.updateSpeedDisplay(this.frontSpeed, speed);
-        } else {
-            this.updateSpeedDisplay(this.rearSpeed, speed);
-        }
-        
-        this.sendNui('aseSpeedDetected', { lane, speed, direction });
-    }
-
-    onLaserTarget(data) {
-        if (!this.isLaserMode) return;
-        
-        const { lane, speed, distance, plate } = data;
-        console.log('[ASEWindow] Laser target:', speed, 'MPH in lane', lane);
-        
-        // Update speed display based on lane
-        if (lane <= 3) {
-            this.updateSpeedDisplay(this.frontSpeed, speed);
-        } else {
-            this.updateSpeedDisplay(this.rearSpeed, speed);
-        }
-        
-        // Update plate if provided
-        if (plate) {
-            this.updatePlate(plate, 'LASER');
-        }
-        
-        this.sendNui('aseLaserTarget', { lane, speed, distance, plate });
-    }
-
-    onPlateDetected(data) {
-        if (!data || !data.plate) return;
-        
-        const { plate, source } = data;
-        console.log('[ASEWindow] Plate detected:', plate, 'from', source);
-        
-        this.updatePlate(plate, source || 'ALPR');
-        this.isScanning = true;
-        this.updateUI();
-        
-        this.sendNui('asePlateDetected', { plate, source });
-    }
-
-    updateSpeedDisplay(element, speed) {
-        if (!element) return;
-        
-        // Format as 3-digit display like radar gun
-        element.textContent = speed.toString().padStart(3, '0');
-        
-        // Remove existing color classes
-        element.classList.remove('under-limit', 'close-limit', 'over-limit');
-        
-        // Add appropriate color class
-        if (speed < this.speedLimit - 5) {
-            element.classList.add('under-limit');
-        } else if (speed <= this.speedLimit + 5) {
-            element.classList.add('close-limit');
-        } else {
-            element.classList.add('over-limit');
-        }
-    }
-
-    updatePlate(plate, source) {
-        this.currentPlate = plate;
-        this.plateText.textContent = plate;
-        this.plateSource.textContent = source;
-        
-        // Render plate glyphs
-        this.renderPlateGlyphs(plate);
-    }
-
-    renderPlateGlyphs(plateNumber) {
-        if (!this.plateGlyphs) return;
-        
-        const safe = (plateNumber || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
-        if (safe.length === 0) {
-            this.plateGlyphs.innerHTML = '';
-            return;
-        }
-        
-        const basePath = 'plates/blue_27x55';
-        const html = Array.from(safe).map(ch => {
-            const name = /[0-9]/.test(ch) ? ch : ch;
-            return `<img class="glyph" alt="${ch}" src="${basePath}/${name}.png">`;
-        }).join('');
-        
-        this.plateGlyphs.innerHTML = html;
-    }
-
-    updatePatrolSpeed(speed) {
-        this.patrolSpeed = speed;
-        this.patrolSpeedValue.textContent = speed.toString().padStart(3, '0');
-    }
-
-    clearAllData() {
-        // Clear speed displays with radar gun format
-        this.frontSpeed.textContent = '000';
-        this.rearSpeed.textContent = '000';
-        this.frontSpeed.classList.remove('under-limit', 'close-limit', 'over-limit');
-        this.rearSpeed.classList.remove('under-limit', 'close-limit', 'over-limit');
-        
-        // Clear plate data
-        this.currentPlate = null;
-        this.plateText.textContent = 'NO PLATE';
-        this.plateSource.textContent = '--';
-        this.plateGlyphs.innerHTML = '';
-        
-        // Reset scanning status
-        this.isScanning = false;
-    }
-
-    updateUI() {
-        // Update power button
-        this.powerBtn.classList.toggle('active', this.isActive);
-        
-        // Update status indicators
-        this.radarStatusDot.classList.toggle('active', this.isActive);
-        this.laserStatusDot.classList.toggle('active', this.isLaserMode);
-        this.plateStatusDot.classList.toggle('scanning', this.isScanning);
-        
-        // Update patrol speed with 3-digit format
-        this.patrolSpeedValue.textContent = this.patrolSpeed.toString().padStart(3, '0');
-    }
-
-    sendNui(action, data = {}) {
-        fetch(`https://frp_mdtui/${action}`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json; charset=UTF-8',
-            },
-            body: JSON.stringify(data),
-        }).then(resp => resp.json()).then(resp => {
-            console.log(`[ASEWindow] NUI callback response: ${action}`, resp);
-        }).catch(error => {
-            console.error(`[ASEWindow] NUI callback error for ${action}:`, error);
-        });
-    }
+  sendNui(action, data = {}) {
+    fetch(`https://frp_mdtui/${action}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=UTF-8' },
+      body: JSON.stringify(data)
+    }).catch(err => console.error('[ASEWindow] NUI error for', action, err));
+  }
 }
 
-// Initialize the ASE window system
 const aseWindow = new ASEWindow();
-
-// Export for use in other scripts
 window.ASEWindow = ASEWindow;
-
-// Initialize ASE window when DOM is loaded
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('[ASEWindow] DOM loaded, initializing ASE window');
-    
-    // Check if ASE window exists
-    const aseWindowElement = document.getElementById('ase-window');
-    if (aseWindowElement) {
-        console.log('[ASEWindow] ASE window found, setting up interface');
-        
-        // Hide the ASE window by default
-        aseWindowElement.style.display = 'none';
-        console.log('[ASEWindow] ASE window hidden by default');
-    } else {
-        console.error('[ASEWindow] ASE window not found during initialization');
-    }
-});


### PR DESCRIPTION
## Summary
- restyle ASE window with self-contained CSS to avoid breaking the main computer UI
- simplify radar markup and script for front, rear, and patrol speed displays
- provide lane buttons for targeting specific lanes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdcd56d8ec83208a8877bc9d3221ba